### PR TITLE
fix msys2 and travis builds (#1118)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
     CYG_MIRROR: http://cygwin.mirror.constant.com
     CYG_PACKAGES: make,gcc-core,clang,pkg-config,libpcre-devel,cmake,python27-setuptools,ruby,mingw64-i686-gcc-core,mingw64-x86_64-gcc-core
-    MSYS_PACKAGES: mingw-w64-x86_64-cmocka mingw-w64-i686-cmocka mingw-w64-x86_64-python2-setuptools mingw-w64-i686-python2-setuptools
+    MSYS_PACKAGES: mingw-w64-x86_64-cmocka mingw-w64-i686-cmocka mingw-w64-x86_64-python3-setuptools mingw-w64-i686-python3-setuptools
     matrix:
         - MSYSTEM: MINGW64
           BASH: C:\msys64\usr\bin\bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 sudo: false
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./install-cmocka-linux.sh; fi
 env:
   - PATH=$PATH:/usr/local/opt/binutils/bin
 script:
@@ -15,40 +13,6 @@ os:
 matrix:
   include:
     - os: linux
-      compiler: gcc
-      env: CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386"
-      script: make && make -C tests/unit test && make -C tests/regress test
-    - os: linux
-      dist: xenial
-      before_install:
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - lib32ncurses5-dev
-            - lib32z1-dev
-            - libpthread-stubs0-dev
-            - lib32gcc-4.8-dev
-            - libc6-dev-i386
-            - gcc-multilib
-            - libcmocka-dev
-    - os: linux
-      dist: xenial
-      before_install:
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - lib32ncurses5-dev
-            - lib32z1-dev
-            - libpthread-stubs0-dev
-            - lib32gcc-4.8-dev
-            - libc6-dev-i386
-            - gcc-multilib
-            - libcmocka-dev
-    - os: linux
-      dist: xenial
-      before_install:
       compiler: gcc
       env: CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386"
       script: make && make -C tests/unit test && make -C tests/regress test
@@ -76,13 +40,8 @@ matrix:
 addons:
   apt:
     packages:
-      - lib32ncurses5-dev
-      - lib32z1-dev
-      - lib32bz2-dev
       - libpthread-stubs0-dev
-      - lib32gcc-4.8-dev
-      - libc6-dev-i386
-      - gcc-multilib
+      - libcmocka-dev
   homebrew:
     update: true
     brewfile: true

--- a/Makefile
+++ b/Makefile
@@ -245,9 +245,9 @@ else
 endif
 ifeq ($(DO_WINDOWS_EXPORT),1)
 ifneq ($(filter MINGW32%,$(UNAME_S)),)
-	cmd /c "windows_export.bat x86"
+	cmd //C "windows_export.bat x86"
 else
-	cmd /c "windows_export.bat x64"
+	cmd //C "windows_export.bat x64"
 endif
 endif
 endif


### PR DESCRIPTION
* fix msys2 builds

* move to travis xenial

now the default

* add i386 cmocka

* move to only different cmocka on 32 bit build

* minimize packages on non x86