### PR TITLE
Fix the error in the hook_code of the arm, calling emu_stop and causi…

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -327,7 +327,8 @@ static tcg_target_ulong cpu_tb_exec(CPUState *cpu, uint8_t *tb_ptr)
         } else {
             assert(cc->set_pc);
             // avoid sync twice when helper_uc_tracecode() already did this.
-            if (env->uc->emu_counter <= env->uc->emu_count && !env->uc->quit_request)
+            if (env->uc->emu_counter <= env->uc->emu_count &&
+                    !env->uc->stop_request && !env->uc->quit_request)
                 cc->set_pc(cpu, tb->pc);
         }
     }


### PR DESCRIPTION
…ng the pc value to be incorrect after the end of the run. (#1157)