### PR TITLE
Add implementation of access to the ARM SPSR register. (#1178)

### DIFF
--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -74,6 +74,9 @@ int arm_reg_read(struct uc_struct *uc, unsigned int *regs, void **vals, int coun
                 case UC_ARM_REG_CPSR:
                     *(int32_t *)value = cpsr_read(&ARM_CPU(uc, mycpu)->env);
                     break;
+                case UC_ARM_REG_SPSR:
+                    *(int32_t *)value = ARM_CPU(uc, mycpu)->env.spsr;
+                    break;
                 //case UC_ARM_REG_SP:
                 case UC_ARM_REG_R13:
                     *(int32_t *)value = ARM_CPU(uc, mycpu)->env.regs[13];
@@ -133,6 +136,9 @@ int arm_reg_write(struct uc_struct *uc, unsigned int *regs, void* const* vals, i
                     break;
                 case UC_ARM_REG_CPSR:
                     cpsr_write(&ARM_CPU(uc, mycpu)->env, *(uint32_t *)value, ~0);
+                    break;
+                case UC_ARM_REG_SPSR:
+                    ARM_CPU(uc, mycpu)->env.spsr = *(uint32_t *)value;
                     break;
                 //case UC_ARM_REG_SP:
                 case UC_ARM_REG_R13:


### PR DESCRIPTION
The SPSR register is named within the Unicorn headers, but the code
to access it is absent. This means that it will always read as 0 and
ignore writes. This makes it harder to work with changes in processor
mode, as the usual way to return from a CPU exception is a
`MOVS pc, lr` for undefined instructions or `SUBS pc, lr, #4`
for most other aborts - which implicitly restores the CPSR from SPSR.

This change adds the access to the SPSR so that it can be read and
written as the caller might expect.